### PR TITLE
Tweak comments and enable more hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@
 ci:
   autofix_prs: false
   autoupdate_branch: pre-commit-updates
+  skip: [cspell]
 
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 # yamllint disable rule:line-length
-# Mostly copied from https://github.com/davidsneighbour/kollitsch.dev/blob/main/.pre-commit-config.yaml
+# Initially copied from https://github.com/davidsneighbour/kollitsch.dev/blob/main/.pre-commit-config.yaml
 # yamllint enable
 ci:
   autofix_prs: false
@@ -53,8 +53,8 @@ repos:
       - id: mixed-line-ending
         # replaces or checks mixed line ending.
         args: [--fix=no]
-      # - id: no-commit-to-branch # - don"t commit to branch
-      #   args: [--branch, main, --branch, "v0.[0-9]"]
+      - id: no-commit-to-branch # - don't commit to branch
+        args: [--branch, main, --branch, "v0.[0-9]"]
       - id: pretty-format-json
         # - Checks that all your JSON files are pretty. "Pretty"
         # here means that keys are sorted and indented.
@@ -104,10 +104,10 @@ repos:
     hooks:
       - id: gitleaks
 
-  # - repo: "https://github.com/jorisroovers/gitlint"
-  #   rev: v0.17.0
-  #   hooks:
-  #     - id: gitlint
+  - repo: "https://github.com/jorisroovers/gitlint"
+    rev: v0.17.0
+    hooks:
+      - id: gitlint
 
   - repo: "https://github.com/editorconfig-checker/editorconfig-checker.python"
     rev: "2.4.0"


### PR DESCRIPTION
Some hooks require at least one pushed commit before they will work.
Enable them now.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>