### PR TITLE
Give up GitHub replaces '@@VAR@@'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @@TITLE@@
+# DFD template
 
-@@DESCRIPTION@@
+Daniel's main template with pre-commit hooks from <https://pre-commit.com>.
 
 ## Status
 
@@ -9,7 +9,7 @@ status](https://results.pre-commit.ci/badge/github/danielfdickinson/dfd-template
 
 ## Repository URL
 
-<@@URL@@>
+<https://github.com/danielfdickinson/dfd-template>
 
 ## Features and default configuration
 


### PR DESCRIPTION
I had hoped that GitHub would auto-insert the title of a new repo in place
of '@@TITLE@@', and so on for description and repo URL. Unfortunately this
does not seem to be a feature of GitHub templates.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>