### PR TITLE
Reduce 'admin noise' in README

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -1,0 +1,35 @@
+# Copyright and licensing
+
+Copyright © 2022 Daniel F. Dickinson
+
+## Textual and media content
+
+Except where otherwise noted, textual and media components in this repository
+are licensed under the Creative Commons Attribution Share-Alike 4.0
+International license. (Basically a 'share it forward' license).
+
+See [LICENSE-TEXT-MEDIA](LICENSE-TEXT-MEDIA) in this repository for
+that license.
+
+## Code and configuration
+
+Except where otherwise noted, and where applicable _([Note 1](#note-1))_, code
+and configurations in this repository are licensed under an MIT license.
+
+See [LICENSE-CODE-AND-CONFIGS](LICENSE-CODE-AND-CONFIGS) in this repository for
+that license.
+
+## Clarification
+
+For the purposes of this repository the word lists are 'config', and the
+[README.md](README.md) is textual.
+
+--------
+
+## Notes
+
+### Note 1
+
+Configurations are not particularly copyrightable anyway, nor do I particularly
+want to, but this makes it clear you can use them on an "AS-IS" basis (i.e.
+please don't sue me if they break or cause breakage).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # DFD template
 
-Daniel's main template with pre-commit hooks from <https://pre-commit.com>.
+Daniel's main template with pre-commit hooks from [pre-commit.com][precommit]
 
-## Status
+## Metadata
+
+### Status
 
 [![pre-commit.ci
 status](https://results.pre-commit.ci/badge/github/danielfdickinson/dfd-template/main.svg)](https://results.pre-commit.ci/latest/github/danielfdickinson/dfd-template/main)
 
-## Repository URL
+### Demo and/or documentation site or page
+
+Not yet created: it may never be. _([Note 3](docs/README-NOTES.md#note-3))_
+
+### Repository URL
 
 <https://github.com/danielfdickinson/dfd-template>
 
@@ -16,21 +22,22 @@ status](https://results.pre-commit.ci/badge/github/danielfdickinson/dfd-template
 **Note**: The default is fairly opinionated (it _is_ primarily for DFD, after
 all), but can be overridden.
 
-* Uses EditorConfig for an editor neutral default styling _([Note 1](#note-1))_
+* Uses [EditorConfig][edconf] for an editor neutral default styling
+_([Note 1](docs/README-NOTES.md#note-1))_
 * Uses pre-commit to do (among other things) linting and spell checking prior
 to a commit succeeding.
 * For this repository we also apply the pre-commit as part of the CI pipeline
 to ensure users have actually used pre-commit locally.
 * Hooks we use (by purpose, not name; for the name refer to
-[the pre-commit config](.pre-commit-config.yaml) in this repo). This are
+[the pre-commit config](.pre-commit-config.yaml) in this repo). This can be
 configured (at the least) to be skipped for certain files or regular
 expressions (python3 regex).
 	* Prevent large files from being committed
 	* Prevent case-only differences in filenames
 	* Prevent having a 'docstring' after code
-	* Require that non-binary executables have a `shebang`
+	* Require that non-binary executables have a 'shebang'
 	* Require JSON files load without error (in Python)
-	* Require that files with a `shebang` are executable
+	* Require that files with a 'shebang' are executable
 	* Prevent committing files with git merge conflict 'leftovers' (e.g. missed
 	markers)
 	* Ensure there are no dangling symlinks
@@ -59,14 +66,14 @@ expressions (python3 regex).
 	* Lints YAML
 	* Lints for secrets about to be committed
 	* Enforces EditorConfig settings for files in repo
-	* Spell checking use [CSpell](https://cspell.org)
-	* Defaults to using the following wordlists
-		* A 'technology' wordlist DFD has on GitHub
-		* A 'misc' wordlist DFD has on GitHub
-		* A project/or repo specific wordlist (starts empty, you can populate).
+	* Spell checking uses [CSpell][cspell]
+	* Defaults to using the following word lists
+		* A 'technology' word list DFD has on GitHub
+		* A 'misc' word list DFD has on GitHub
+		* A project/or repo specific word list (starts empty, you can populate).
 	* Dictionaries to apply can be overridden for certain paths or file types
 		* For example you could use a french dictionary for certain files
-		* TODO: Plans are to increase the number of words in Daniel's wordlists
+		* TODO: Plans are to increase the number of words in Daniel's word lists
 		and to split into 'tech slang', 'tech', 'missing words (en_CA bias)'
 		for the default dictionaries, 'slang missing words', and 'french words
 		(fr_CA bias)', and 'DFD words' (e.g. variable names and such used in
@@ -76,7 +83,7 @@ expressions (python3 regex).
 
 ### Initialize your new repository
 
-1. Make sure you have [pre-commit](https://pre-commit.com) installed.
+1. Make sure you have [pre-commit][precommit] installed.
 2. From the Web UI, choose this template when creating a new repository.
 3. Clone the new repository to your local workstation.
 4. Change to the directory created by cloning the new repo.
@@ -92,59 +99,20 @@ expressions (python3 regex).
 And notice that many mistakes are flagged and need to be fixed before
 you are able to commit. This helps keep things in great shape.
 
-## Copyright and licensing
+## Getting help, discussing, and/or modifying
 
-Copyright © 2022 Daniel F. Dickinson
-
-### Textual and media content
-
-Except where otherwise noted, textual and media components in this repository
-are licensed under the Creative Commons Attribution Share-Alike 4.0
-International license. (Basically a 'share it forward' license).
-
-See [LICENSE-TEXT-MEDIA](LICENSE-TEXT-MEDIA) in this repository for
-that license.
-
-### Code and configuration
-
-Except where otherwise noted, and where applicable _([Note 2](#note-2))_, code
-and configurations in this repository are licensed under an MIT license.
-
-See [LICENSE-CODE-AND-CONFIGS](LICENSE-CODE-AND-CONFIGS) in this repository for
-that license.
-
-### Acknowledgements
-
-Thank you to '@davidsneighbour' for introducing me to
-[pre-commit](https://pre-commit.com) and whose configurations I have gleefully
-extended (for example adding [CSpell][cspell] for spell checking).
-
-Thank you to '@brycewray' for writing an excellent [article on the
-accessibility argument for tabs vs spaces in code][tabaccess]. Hopefully I
-haven't taken that _too_ far (_[Note 1](#note-1)_).
+* [Support and general questions](docs/SUPPORT.md)
+* [Bugs and feature requests](docs/SUPPORT.md)
+* [Contributing modifications to the repository](docs/CONTRIBUTING.md)
 
 -------
 
-## Notes
+## Colophon
 
-### Note 1
-
-Uses EditorConfig for an editor neutral default styling
-
-* Defaults to [using tabs where possible for accessibility
-reasons][tabaccess]
-* `root = false` so that the user can set their preferred (or required for
-accessibility reasons) rendering of the tabs via a `.editorconfig` file in
-a higher level directory, or their home directory. Not doing this defeats
-the purpose of using tabs vs. spaces.
-* `tab_width` is **not** set in this repository so that the user's config
-will be used. (See above).
-
-### Note 2
-
-Configurations are not particularly copyrightable anyway, nor do I particularly
-want to, but this makes it clear you can use them on an "AS-IS" basis (i.e.
-please don't sue me if they break or cause breakage).
+* [Copyright and licensing](COPYING.md)
+* [Inspirations, information, and source material](docs/ACKNOWLEDGEMENTS.md)
+* [Notes](docs/README-NOTES.md)
 
 [cspell]: https://cspell.org
-[tabaccess]: https://www.brycewray.com/posts/2022/06/accessibility-argument-tabs-spaces/
+[edconf]: https://editorconfig.org/
+[precommit]: https://pre-commit.com

--- a/docs/ACKNOWLEDGEMENTS.md
+++ b/docs/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,16 @@
+# Acknowledgements
+
+## Thank you
+
+* '@davidsneighbour' for introducing me to [pre-commit][precommit] and whose
+configurations I have gleefully extended (for example adding
+[CSpell][cspell] for spell checking).
+* '@brycewray' for writing an excellent [article on the accessibility argument
+for tabs vs spaces in code][tabaccess]. Hopefully I haven't taken that _too_
+far (_[Note 1](../README.md#note-1)_).
+
+--------
+
+[cspell]: https://cspell.org
+[precommit]: https://pre-commit.com
+[tabaccess]: https://www.brycewray.com/posts/2022/06/accessibility-argument-tabs-spaces/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Please [check for open issues][open-issues] for enhancements and
+bugs that you would like resolved, write the solution, and submit a
+Pull Request!
+
+Alternatively, if [your bug or feature request can't be found when searching
+both open and closed issues][issues], please create a new issue, and if you
+can, create a Pull Request as mentioned in the paragraph above.
+
+Adding and improving documentation is always welcomed, as well.
+
+[issues]: https://github.com/danielfdickinson/dfd-template/issues?q=is%3Aissue
+[open-issues]: https://github.com/danielfdickinson/dfd-template/issues?q=is%3Aissue+is%3Aopen

--- a/docs/README-NOTES.md
+++ b/docs/README-NOTES.md
@@ -1,0 +1,42 @@
+# Notes
+
+## Note 1
+
+Uses [EditorConfig](edconf) for an editor neutral default styling
+
+* Defaults to [using tabs where possible for accessibility
+reasons][tabaccess]
+* `root = false` so that the user can set their preferred (or required for
+accessibility reasons) rendering of the tabs via a `.editorconfig` file in
+a higher level directory, or their home directory. Not doing this defeats
+the purpose of using tabs vs. spaces.
+* `tab_width` is **not** set in this repository so that the user's config
+will be used. (See above).
+
+## Note 2
+
+'We' is the 'royal we' (because we don't like saying 'I' a lot and often we
+want speak in the first person), and 'I' am
+[@danielfdickinson](https://github.com/danielfdickinson).
+
+## Note 3
+
+This repository uses [pre-commit][precommit] to filter out (and potentially
+auto-fix) issues with many minor (and some not so minor) 'nits'.
+
+The developer who introduced me to pre-commit has written [a blog post giving
+some context and general information on the use
+of
+'pre-commit'][dnbprecommit],
+and the official docs are pretty good too, so perhaps that will suffice.
+
+He prefers a different code spell checker though, but [the README for the word
+lists I use with CSpell][dfdwordsdoc] has some info on [CSpell][cspell].
+
+--------
+
+[cspell]: https://cspell.org
+[dfdwordsdoc]: https://github.com/danielfdickinson/dfd-wordlists#readme
+[dnbprecommit]: https://kollitsch.dev/blog/2022/simple-multi-language-pre-commit-hooks/
+[precommit]: https://pre-commit.com
+[tabaccess]: https://www.brycewray.com/posts/2022/06/accessibility-argument-tabs-spaces/

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support options
+
+1. Check the [README.md](../README.md)
+2. Try [Discussions for support and general questions][discussions]
+3. If [your bug or feature request can't be found when searching both open
+and closed issues][issues], please create a new issue.
+4. For matters which require privacy, please use [my published email
+address][dfdmail]
+
+--------
+
+[discussions]: https://github.com/danielfdickinson/dfd-template/discussions
+[dfdmail]: mailto:dfdpublic@wildtechgarden.ca
+[issues]: https://github.com/danielfdickinson/dfd-template/issues?q=is%3Aissue

--- a/tests/config/words-project.txt
+++ b/tests/config/words-project.txt
@@ -1,1 +1,2 @@
-
+administrivia
+edconf


### PR DESCRIPTION
Split out much administrivia from README.md. In the process
we create repo-specific 'community health' files for SUPPORT and
CONTRIBUTING, as well as create a COPYING file with copyright and
licensing information.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>